### PR TITLE
Frontend-Sprache an User Objekte anhängen

### DIFF
--- a/src/components/Account.vue
+++ b/src/components/Account.vue
@@ -141,7 +141,10 @@ export default {
       })
     },
     submitForm () {
-      api.$http.post(api.urls.update_user, this.user).then((data) => {
+      let userData = Object.assign({}, this.user);
+      userData.preferred_language = this.$root.$i18n.locale
+
+      api.$http.post(api.urls.update_user, userData).then((data) => {
         this.msg = 'account_saved'
       }).catch(() => {
         this.msg = 'error_saving_account'

--- a/src/components/Account.vue
+++ b/src/components/Account.vue
@@ -141,7 +141,7 @@ export default {
       })
     },
     submitForm () {
-      let userData = Object.assign({}, this.user);
+      let userData = Object.assign({}, this.user)
       userData.preferred_language = this.$root.$i18n.locale
 
       api.$http.post(api.urls.update_user, userData).then((data) => {

--- a/src/components/Register.vue
+++ b/src/components/Register.vue
@@ -123,7 +123,10 @@ export default {
       this.submitForm()
     },
     submitForm () {
-      api.$http.post(api.urls.signup_url, this.user).then((data) => {
+      let userData = Object.assign({}, this.user);
+      userData.preferred_language = this.$root.$i18n.locale
+
+      api.$http.post(api.urls.signup_url, userData).then((data) => {
         this.success = true
         this.msg = false
       }).catch((err) => {

--- a/src/components/Register.vue
+++ b/src/components/Register.vue
@@ -123,7 +123,7 @@ export default {
       this.submitForm()
     },
     submitForm () {
-      let userData = Object.assign({}, this.user);
+      let userData = Object.assign({}, this.user)
       userData.preferred_language = this.$root.$i18n.locale
 
       api.$http.post(api.urls.signup_url, userData).then((data) => {


### PR DESCRIPTION
Fixing #15 

@Skeeve @Skeeve habe die Webapp jetzt dahingehend modifiziert, dass die beim Registrieren bzw. Profil bearbeiten gesetzte Frontend-Sprache mit an die API übermittelt wird, bitte mal reviewen, danach merge ich es in dev und wir können in der Staging testen ob die Daten dann auch in der DB landen.