### PR TITLE
PDF Print

### DIFF
--- a/env.example.js
+++ b/env.example.js
@@ -1,8 +1,0 @@
-export default {
-  APP_NAME: '',
-  // dev or production
-  APP_ENV: '',
-  APP_URL: '',
-  // Token to access the user object via sessionStorage or localStorage
-  ID_TOKEN: ''
-}

--- a/env.example.js
+++ b/env.example.js
@@ -1,0 +1,8 @@
+export default {
+  APP_NAME: '',
+  // dev or production
+  APP_ENV: '',
+  APP_URL: '',
+  // Token to access the user object via sessionStorage or localStorage
+  ID_TOKEN: ''
+}

--- a/i18n/de/common.js
+++ b/i18n/de/common.js
@@ -15,7 +15,8 @@ const common = {
   download: 'Download',
   copy: 'Kopieren',
   verify: 'Bestätigen',
-  scan_start: 'Neuen Scan starten'
+  scan_start: 'Neuen Scan starten',
+  pdf_link: 'Pdf link'
 }
 
 export default common

--- a/i18n/de/common.js
+++ b/i18n/de/common.js
@@ -16,7 +16,7 @@ const common = {
   copy: 'Kopieren',
   verify: 'Bestätigen',
   scan_start: 'Neuen Scan starten',
-  pdf_link: 'Pdf link'
+  pdf_link: 'Report als PDF'
 }
 
 export default common

--- a/i18n/en/common.js
+++ b/i18n/en/common.js
@@ -15,7 +15,8 @@ const common = {
   download: 'Download',
   copy: 'Copy',
   verify: 'Verify',
-  scan_start: 'Scan start'
+  scan_start: 'Scan start',
+  pdf_link: 'Pdf link'
 }
 
 export default common

--- a/i18n/en/common.js
+++ b/i18n/en/common.js
@@ -16,7 +16,7 @@ const common = {
   copy: 'Copy',
   verify: 'Verify',
   scan_start: 'Scan start',
-  pdf_link: 'Pdf link'
+  pdf_link: 'Report as PDF'
 }
 
 export default common

--- a/package-lock.json
+++ b/package-lock.json
@@ -2874,7 +2874,8 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "coa": {
       "version": "2.0.2",
@@ -5423,7 +5424,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5444,12 +5446,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5464,17 +5468,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5591,7 +5598,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5603,6 +5611,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5617,6 +5626,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5624,12 +5634,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5648,6 +5660,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5728,7 +5741,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5740,6 +5754,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5825,7 +5840,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5861,6 +5877,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5880,6 +5897,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5923,12 +5941,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10137,7 +10157,8 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",

--- a/src/components/DomainListHead.vue
+++ b/src/components/DomainListHead.vue
@@ -48,6 +48,9 @@ export default {
     }
   },
   methods: {
+    /**
+     *@return {void}
+     */
     reverseState () {
       this.show = !this.show
 

--- a/src/components/DomainListHeadBase.vue
+++ b/src/components/DomainListHeadBase.vue
@@ -5,15 +5,17 @@
       {{ localeDate }}
     </span>
     <ButtonDomainDelete :domain="report.domain" />
+    <PDFPrint :domain="report.domain"/>
   </div>
 </template>
 
 <script>
 import ButtonDomainDelete from './ButtonDomainDelete'
 import { mapGetters } from 'vuex'
+import PDFPrint from './PDFPrint'
 export default {
   name: 'DomainListHeadBase',
-  components: { ButtonDomainDelete },
+  components: { PDFPrint, ButtonDomainDelete },
   computed: {
     ...mapGetters('language', ['language']),
     localeDate () {

--- a/src/components/PDFPrint.vue
+++ b/src/components/PDFPrint.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="report-link">
+    <form
+      v-if="hasBeenScanned"
+      method="post"
+      :action="url">
+      <input
+        type="hidden"
+        name="SIWECOS-Token"
+        :value="token" />
+      <input
+        type="submit"
+        :value="$t('common.pdf_link')" />
+    </form>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import env from '../../env'
+export default {
+  name: 'PDFPrint',
+  data () {
+    return {
+      link: ''
+    }
+  },
+  props: {
+    domain: {
+      type: String
+    }
+  },
+  computed: {
+    ...mapGetters('language', ['language']),
+    ...mapGetters('domains', ['scanId']),
+    ...mapGetters('account', ['token']),
+    url () {
+      return `${env.APP_URL}/api/v2/scan/${this.scanId.scanId}/${this.language}/pdf`
+    },
+    hasBeenScanned () {
+      if (this.scanId === null) {
+        return false
+      }
+
+      return this.scanId.scanId && this.scanId.domain === this.domain
+    }
+  }
+}
+</script>

--- a/src/components/Scan.vue
+++ b/src/components/Scan.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapActions, mapMutations } from 'vuex'
 export default {
   name: 'Scan',
   data () {
@@ -21,9 +21,12 @@ export default {
   },
   methods: {
     ...mapActions('domains', ['fetch']),
+    ...mapMutations('domains', ['setScanId']),
     async scan () {
+      let response
+
       try {
-        const response = await this.$api.create(`scan`, { domain: this.domain })
+        response = await this.$api.create(`scan`, { domain: this.domain })
 
         this.isDisabled = true
         this.checkScanStatus(response.scan_id, 'running')
@@ -41,6 +44,7 @@ export default {
     async checkScanStatus (id, progress) {
       if (progress === 'finished') {
         this.fetch()
+        this.setScanId({ domain: this.domain, scanId: id })
         return
       }
 

--- a/src/modules/account.js
+++ b/src/modules/account.js
@@ -46,9 +46,9 @@ const getters = {
   token (state) {
     return state.token
       ? state.token
-      : sessionStorage.getItem('token')
-        ? sessionStorage.getItem('token')
-        : localStorage.getItem('token') || ''
+      : sessionStorage.getItem(env.ID_TOKEN)
+        ? sessionStorage.getItem(env.ID_TOKEN)
+        : localStorage.getItem(env.ID_TOKEN) || ''
   },
   /**
    *

--- a/src/modules/domains.js
+++ b/src/modules/domains.js
@@ -1,7 +1,8 @@
 import Api from '../services/api'
 
 const state = {
-  domains: []
+  domains: [],
+  scanId: null
 }
 
 const getters = {
@@ -12,6 +13,14 @@ const getters = {
    */
   domains (state) {
     return state.domains
+  },
+  /**
+   *
+   * @param state
+   * @return {*}
+   */
+  scanId (state) {
+    return state.scanId
   }
 }
 
@@ -23,6 +32,15 @@ const mutations = {
    */
   setDomains (state, domains) {
     state.domains = domains
+  },
+
+  /**
+   *
+   * @param state
+   * @param id
+   */
+  setScanId (state, id) {
+    state.scanId = id
   }
 }
 


### PR DESCRIPTION
## Sum up

Nach einem Scan-Vorgang soll es möglich sein, sich das Protokoll als PDF-Datei ausgeben zu lassen.

Diese Funktion wurde anhand eines Buttons realisiert, der in der jeweiligen Domainübersicht zu sehen ist, wenn der Scan-Vorgang abgesschlossen ist.

Beim klicken dieses Buttons sollte sich ein Dialogfenster öffnen, mit der Frage, ob man die Datei speichern möchte.

## How to:

1. Gehe auf die Seite `/domains`
2. Starte einen Scan der jeweiligen Domain
3. Scan-Vorgang abwarten, bis er abgeschlossen ist
4. Auf den gerade erschienen Button: `Pdf link` klicken
5. Datei speichern