### PR TITLE
Ermögliche dem Benutzer, eine Domain, anstelle einer URL anzugeben

### DIFF
--- a/i18n/de/rules.js
+++ b/i18n/de/rules.js
@@ -3,7 +3,7 @@ const rules = {
   min: 'Das Feld muss mindestens {length} Zeichen verwenden.',
   email: 'This field must be a valid email.',
   confirmed: 'Dieses Feld stimmt nicht mit dem vorherigen überein.',
-  url: 'Ungültige E-Mail.'
+  url: 'Ungültiger Domainname.'
 }
 
 export default rules

--- a/i18n/de/sections/domains.js
+++ b/i18n/de/sections/domains.js
@@ -3,7 +3,7 @@ const domains = {
   add: 'Domain hinzufügen',
   headline_add: 'Domain hinzufügen',
   none_available: 'Keine Domains vorhanden',
-  add_example: 'Domain, bspws. https://www.example.org',
+  add_example: 'Domain, bspws. example.org',
   delete_domain: 'Domain entfernen',
   more_about: 'Was bedeutet der SIWECOS Score?',
   show_details: 'Mehr Informationen',

--- a/i18n/en/rules.js
+++ b/i18n/en/rules.js
@@ -3,7 +3,7 @@ const rules = {
   min: 'This field must be {length} characters long.',
   email: 'Please enter a valid email',
   confirmed: 'Fields do not match up',
-  url: 'Please enter a valid URL'
+  url: 'Please enter a valid domain'
 }
 
 export default rules

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,11 @@ extend('required', required)
 extend('min', min)
 extend('email', email)
 extend('confirmed', confirmed)
+extend('url', {
+  validate: value => {
+    return value.includes('.') && !value.includes(...['http', 'https'])
+  }
+})
 
 configure({
   // this will be used to generate messages.

--- a/src/views/TheDomainsAdd.vue
+++ b/src/views/TheDomainsAdd.vue
@@ -69,11 +69,11 @@ export default {
       if (!valid) return
 
       try {
-        await this.$api.create('domain', { domain: this.adjustDomain(this.domain) })
+        await this.$api.create('domain', { domain: this.domain })
 
         await this.fetch()
 
-        this.$router.push({ path: `/domain/verify/${this.adjustDomain(this.domain)}` })
+        this.$router.push({ path: `/domain/verify/${this.domain}` })
       } catch (e) {
         if (Object.keys(e.data).length > 0) {
           this.response.data = e.data
@@ -81,27 +81,6 @@ export default {
 
         this.response.code = e.status
       }
-    },
-    /**
-     *
-     * @param domain
-     * @return {string|*}
-     */
-    adjustDomain (domain) {
-      const blacklist = ['http://', 'https://', 'www.']
-      let url = domain
-
-      if (typeof domain !== 'string') return ''
-
-      blacklist.forEach(item => {
-        const position = domain.indexOf(item)
-
-        if (position !== -1) {
-          url = domain.slice(position + item.length, domain.length)
-        }
-      })
-
-      return url
     }
   }
 }

--- a/src/views/TheDomainsAdd.vue
+++ b/src/views/TheDomainsAdd.vue
@@ -16,10 +16,10 @@
             tag="div"
             mode="passive"
             name="domain"
-            rules="required"
+            rules="required|url"
             v-slot="{ errors }">
             <input
-              type="url"
+              type="text"
               v-model="domain"
               name="domain"
               id="domain"


### PR DESCRIPTION
In der neuen API werden nur noch Domains, aber nicht URLs übergeben. Deswegen soll es dem Benutzer erlaubt sein, eine gültige Domain anstelle einer vollständigen URL anzugeben.

Related issue: https://github.com/SIWECOS/webapp/issues/42