### PR TITLE
Create a jump link for scan results

### DIFF
--- a/i18n/de/sections/domains.js
+++ b/i18n/de/sections/domains.js
@@ -9,7 +9,8 @@ const domains = {
   show_details: 'Mehr Informationen',
   hide_details: 'Weniger Informationen',
   delete_domain_confirm: 'Möchten Sie diese Domain wirklich löschen?',
-  verify_domain: 'Domain bestätigen'
+  verify_domain: 'Domain bestätigen',
+  jumplink: 'Zurück zur Übersicht'
 }
 
 export default domains

--- a/i18n/en/sections/domains.js
+++ b/i18n/en/sections/domains.js
@@ -9,7 +9,8 @@ const domains = {
   show_details: 'Show details',
   hide_details: 'Hide details',
   delete_domain_confirm: 'Are you sure you want to delete this domain?',
-  verify_domain: 'Verify domain'
+  verify_domain: 'Verify domain',
+  jumplink: 'Get back to the overview'
 }
 
 export default domains

--- a/src/components/DomainList.vue
+++ b/src/components/DomainList.vue
@@ -20,7 +20,7 @@
               :report="report.report"
               :id="report.id.toString()" />
             <DomainListReports
-              :id="key.toString()"
+              :id="report.id.toString()"
               :report="report.report" />
           </section>
         </div>

--- a/src/components/DomainListDoughnuts.vue
+++ b/src/components/DomainListDoughnuts.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="content__overview">
+  <div
+    :id="id"
+    class="content__overview">
     <div
       class="itemoverview__testometercontainer"
       v-for="(details, key) in report"

--- a/src/components/DomainListDoughnuts.vue
+++ b/src/components/DomainListDoughnuts.vue
@@ -7,9 +7,11 @@
       <div
         id="testometer__scanner1"
         class="testometer">
-        <Doughnut
-          :score="details.score"
-          :id="`${id}__content__${key}`"/>
+        <a :href="`#${id}_${details.scanner_name}`">
+          <Doughnut
+            :score="details.score"
+            :id="`${id}__content__${key}`"/>
+        </a>
         <span class="testometer__result">
             {{ details.score }}
           </span>

--- a/src/components/DomainListReports.vue
+++ b/src/components/DomainListReports.vue
@@ -42,6 +42,11 @@
           </div>
         </div>
       </div>
+      <a
+        class="jumplink"
+        :href="`#${id}`">
+        {{ $t('domains.jumplink') }}
+      </a>
     </section>
   </div>
 </template>

--- a/src/components/DomainListReports.vue
+++ b/src/components/DomainListReports.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="content__detail">
     <section
+      :id="`${id}_${detail.scanner_name}`"
       class="detail__contentsection"
       v-for="(detail, scannerKey) in report"
       :key="scannerKey">


### PR DESCRIPTION
Wie in diesem Issue beschrieben: https://github.com/SIWECOS/webapp/issues/37 soll es möglich sein, von den scan reports zurückzuspringen und vice verca. Beim klicken eines Tachos, springt man direkt zum jeweiligen ergebnis.