### PR TITLE
Loading Spinner als Rückmeldung für den Start eines Scans

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,15 @@
 <template>
   <div id="app">
+    <LoadingSpinner />
     <router-view/>
   </div>
 </template>
 <script>
 import { mapMutations } from 'vuex'
+import LoadingSpinner from './components/LoadingSpinner'
 export default {
   name: 'App',
+  components: { LoadingSpinner },
   mounted () {
     this.setLanguage(document.querySelector('html').getAttribute('lang').substr(0, 2))
   },

--- a/src/components/LoadingSpinner.vue
+++ b/src/components/LoadingSpinner.vue
@@ -1,0 +1,121 @@
+<template>
+  <div
+    v-if="spinning"
+    class="spinner">
+    <div
+      class="lds-roller">
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+export default {
+  name: 'LoadingSpinner',
+  computed: {
+    ...mapGetters('loadingSpinner', ['spinning'])
+  }
+}
+</script>
+
+<style scoped>
+  .spinner {
+    position: fixed;
+    height: 100vh;
+    width: 100%;
+    background: rgba(255, 255, 255, 0.9)
+  }
+  .lds-roller {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    width: 64px;
+    height: 64px;
+  }
+  .lds-roller div {
+    animation: lds-roller 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+    transform-origin: 32px 32px;
+  }
+  .lds-roller div:after {
+    content: " ";
+    display: block;
+    position: absolute;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #000;
+    margin: -3px 0 0 -3px;
+  }
+  .lds-roller div:nth-child(1) {
+    animation-delay: -0.036s;
+  }
+  .lds-roller div:nth-child(1):after {
+    top: 50px;
+    left: 50px;
+  }
+  .lds-roller div:nth-child(2) {
+    animation-delay: -0.072s;
+  }
+  .lds-roller div:nth-child(2):after {
+    top: 54px;
+    left: 45px;
+  }
+  .lds-roller div:nth-child(3) {
+    animation-delay: -0.108s;
+  }
+  .lds-roller div:nth-child(3):after {
+    top: 57px;
+    left: 39px;
+  }
+  .lds-roller div:nth-child(4) {
+    animation-delay: -0.144s;
+  }
+  .lds-roller div:nth-child(4):after {
+    top: 58px;
+    left: 32px;
+  }
+  .lds-roller div:nth-child(5) {
+    animation-delay: -0.18s;
+  }
+  .lds-roller div:nth-child(5):after {
+    top: 57px;
+    left: 25px;
+  }
+  .lds-roller div:nth-child(6) {
+    animation-delay: -0.216s;
+  }
+  .lds-roller div:nth-child(6):after {
+    top: 54px;
+    left: 19px;
+  }
+  .lds-roller div:nth-child(7) {
+    animation-delay: -0.252s;
+  }
+  .lds-roller div:nth-child(7):after {
+    top: 50px;
+    left: 14px;
+  }
+  .lds-roller div:nth-child(8) {
+    animation-delay: -0.288s;
+  }
+  .lds-roller div:nth-child(8):after {
+    top: 45px;
+    left: 10px;
+  }
+  @keyframes lds-roller {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/src/components/LoadingSpinner.vue
+++ b/src/components/LoadingSpinner.vue
@@ -31,7 +31,8 @@ export default {
     position: fixed;
     height: 100vh;
     width: 100%;
-    background: rgba(255, 255, 255, 0.9)
+    background: rgba(255, 255, 255, 0.8);
+    z-index: 100;
   }
   .lds-roller {
     position: fixed;

--- a/src/components/Scan.vue
+++ b/src/components/Scan.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapActions, mapMutations } from 'vuex'
 export default {
   name: 'Scan',
   data () {
@@ -21,7 +21,9 @@ export default {
   },
   methods: {
     ...mapActions('domains', ['fetch']),
+    ...mapMutations('loadingSpinner', ['setSpinning']),
     async scan () {
+      this.setSpinning(true)
       try {
         const response = await this.$api.create(`scan`, { domain: this.domain })
 
@@ -29,6 +31,7 @@ export default {
         this.checkScanStatus(response.scan_id, 'running')
         this.isDisabled = false
       } catch (e) {
+        this.setSpinning(false)
         this.isDisabled = false
       }
     },
@@ -41,6 +44,7 @@ export default {
     async checkScanStatus (id, progress) {
       if (progress === 'finished') {
         this.fetch()
+        this.setSpinning(false)
         return
       }
 

--- a/src/modules/loadingSpinner.js
+++ b/src/modules/loadingSpinner.js
@@ -1,0 +1,32 @@
+const state = {
+  spinning: false
+}
+
+const getters = {
+  /**
+   *
+   * @param state
+   * @return {boolean}
+   */
+  spinning (state) {
+    return state.spinning
+  }
+}
+
+const mutations = {
+  /**
+   *
+   * @param state
+   * @param isSpinning
+   */
+  setSpinning (state, isSpinning) {
+    state.spinning = isSpinning
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations
+}

--- a/src/store.js
+++ b/src/store.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex'
 import account from './modules/account'
 import domains from './modules/domains'
 import language from './modules/language'
+import loadingSpinner from './modules/loadingSpinner'
 
 Vue.use(Vuex)
 
@@ -19,6 +20,10 @@ export default new Vuex.Store({
     language: {
       namespaced: true,
       ...language
+    },
+    loadingSpinner: {
+      namespaced: true,
+      ...loadingSpinner
     }
   }
 })


### PR DESCRIPTION
https://github.com/SIWECOS/webapp/issues/51 in diesem Ticket wurde angemerkt, dass es keinerlei Rückmeldung dazu gäbe, wenn man einen Scan gestartet hat. Aus Benutzersicht ist das natürlich blöd, weil man weder weiß, wann der Scan gestartet hat, noch, wann er beendet wurde.

Deswegen habe ich einen sog. "Loading Spinner" eingebaut, der zentralisiert am Bildschirm angezeigt wird und sich solange dreht, bis der Scan abgeschlossen wurde.