### PR TITLE
Anzeige der verifizierten Domain, nachdem sie verifiziert wurde.

### DIFF
--- a/src/components/DomainList.vue
+++ b/src/components/DomainList.vue
@@ -100,7 +100,13 @@ export default {
       let reports = []
 
       for (let domain of domains) {
-        const report = await this.$api.get(`domain/${domain.domain}/report/${this.language}`)
+        let report
+
+        try {
+          report = await this.$api.get(`domain/${domain.domain}/report/${this.language}`)
+        } catch (e) {
+          continue
+        }
 
         Reflect.set(report, 'domain', domain.domain)
         Reflect.set(report, 'verified', domain.is_verified)
@@ -115,6 +121,7 @@ export default {
      */
     getVerifiedDomains () {
       this.verified = []
+      console.log(this.domains)
 
       for (let domain of this.domains) {
         if (!domain.is_verified) {

--- a/src/components/DomainList.vue
+++ b/src/components/DomainList.vue
@@ -100,7 +100,7 @@ export default {
       let reports = []
 
       for (let domain of domains) {
-        let report
+        let report = {}
 
         try {
           report = await this.$api.get(`domain/${domain.domain}/report/${this.language}`)

--- a/src/components/DomainList.vue
+++ b/src/components/DomainList.vue
@@ -121,7 +121,6 @@ export default {
      */
     getVerifiedDomains () {
       this.verified = []
-      console.log(this.domains)
 
       for (let domain of this.domains) {
         if (!domain.is_verified) {

--- a/src/modules/domains.js
+++ b/src/modules/domains.js
@@ -37,6 +37,14 @@ const mutations = {
   /**
    *
    * @param state
+   */
+  clearDomains (state) {
+    state.domains = []
+  },
+
+  /**
+   *
+   * @param state
    * @param id
    */
   setScanId (state, id) {

--- a/src/views/TheDomainVerify.vue
+++ b/src/views/TheDomainVerify.vue
@@ -115,6 +115,8 @@ export default {
     async verify () {
       try {
         await this.$api.create('domain/verify', { domain: this.domain })
+
+        this.$router.push('/domains')
       } catch (e) {
         this.response.code = e.status
       }

--- a/src/views/TheDomains.vue
+++ b/src/views/TheDomains.vue
@@ -21,21 +21,21 @@
 </template>
 
 <script>
-import { mapActions, mapGetters } from 'vuex'
+import { mapActions, mapGetters, mapMutations } from 'vuex'
 import DomainList from '../components/DomainList'
 export default {
   name: 'TheDomains',
   components: { DomainList },
   mounted () {
-    if (!this.domains.length) {
-      this.fetch()
-    }
+    this.clearDomains()
+    this.fetch()
   },
   computed: {
     ...mapGetters('domains', ['domains'])
   },
   methods: {
-    ...mapActions('domains', ['fetch'])
+    ...mapActions('domains', ['fetch']),
+    ...mapMutations('domains', ['clearDomains'])
   }
 }
 </script>


### PR DESCRIPTION
Ich habe in diesem PR zwei **Bugs** behoben:

1. Bei dem ersten handelt es sich um das Hauptproblem: Nachdem eine Domain verifiziert wurde, wurde man weder weitergeleitet, noch hat sich die Domainliste aktualisiert.
2. Beim zweiten Bug ging es um das Anzeigen von Reporten. Diese wurden unvollständig oder gar nicht angezeigt, wenn es Domains gab, die noch keinen Scan hatten. Dadurch wurde die ``for...of`` Schleife vom 40* HTTP-Error unterbrochen. Wenn eine Domain noch nicht gescanned wurde, wird ein ``continue`` eingesetzt und der Fetch kann fortgeführt werden.

**Soll:**

1. Die aktuell verifizierte Domain sollte sofort erscheinen, nachdem man sie verifiziert hat.
2. Für alle bereits gescannten Domains, sollte ganz normal der Score angezeigt werden, unabhängig davon, ob auch Domains gelistet sind, die noch nicht gescannt wurden