### PR TITLE
Neuer Text für die Bestätigung beim löschen einer Domain

### DIFF
--- a/i18n/de/sections/domains.js
+++ b/i18n/de/sections/domains.js
@@ -8,7 +8,7 @@ const domains = {
   more_about: 'Was bedeutet der SIWECOS Score?',
   show_details: 'Mehr Informationen',
   hide_details: 'Weniger Informationen',
-  delete_domain_confirm: 'Möchten Sie diese Domain wirklich löschen?',
+  delete_domain_confirm: 'Möchten Sie die Domain: {url} wirklich löschen?',
   verify_domain: 'Domain bestätigen',
   jumplink: 'Zurück zur Übersicht'
 }

--- a/i18n/en/sections/domains.js
+++ b/i18n/en/sections/domains.js
@@ -8,7 +8,7 @@ const domains = {
   more_about: 'More about the SIWECOS score',
   show_details: 'Show details',
   hide_details: 'Hide details',
-  delete_domain_confirm: 'Are you sure you want to delete this domain?',
+  delete_domain_confirm: 'Are you sure you want to delete the domain: {url}?',
   verify_domain: 'Verify domain',
   jumplink: 'Get back to the overview'
 }

--- a/src/components/ButtonDomainDelete.vue
+++ b/src/components/ButtonDomainDelete.vue
@@ -21,7 +21,7 @@ export default {
      * @return {Promise<void>}
      */
     async destroy (url) {
-      const isConfirmed = confirm(this.$t('domains.delete_domain_confirm'))
+      const isConfirmed = confirm(this.$tc('domains.delete_domain_confirm', url, { url }))
 
       if (!isConfirmed) return
 


### PR DESCRIPTION
Im Issue: https://github.com/SIWECOS/webapp/issues/58 wurde angefragt, den Text zu ändern. Dabei wird jetzt immer auch der Domainname mit hinzugefügt.