### PR TITLE
Anpassung der Report-Zuordnung & Anzeige der Bewertungen

### DIFF
--- a/src/components/DomainList.vue
+++ b/src/components/DomainList.vue
@@ -33,6 +33,8 @@ export default {
      * @return {void}
      */
     verified (domains) {
+      this.reports = []
+
       this.setReports(domains).then(reports => {
         this.reports = reports
       })

--- a/src/components/DomainList.vue
+++ b/src/components/DomainList.vue
@@ -33,12 +33,13 @@ export default {
      * @return {void}
      */
     verified (domains) {
-      this.reports = []
-
       this.setReports(domains).then(reports => {
         this.reports = reports
       })
     },
+    /**
+     * @return {void}
+     */
     domains () {
       this.getVerifiedDomains()
     }

--- a/src/components/DomainListHead.vue
+++ b/src/components/DomainListHead.vue
@@ -4,13 +4,10 @@
       :domain="domain"
       :report="report"/>
     <div
-      v-if="hasReport"
       id="testometer__general"
       class="testometer itemhead__testometer">
-      <Doughnut
-        :score="report.score"
-        :id="report.id.toString()" />
-      <span class="testometer__result"> {{ report.score }} </span>
+      <Doughnut :score="getScore"/>
+      <span class="testometer__result"> {{ getScore }} </span>
     </div>
     <Scan :domain="domain.domain"/>
     <a
@@ -41,6 +38,9 @@ export default {
   computed: {
     hasReport () {
       return Object.keys(this.report).length > 0
+    },
+    getScore () {
+      return this.report.score || 0
     }
   },
   data () {
@@ -61,7 +61,7 @@ export default {
   },
   methods: {
     /**
-     *@return {void}
+     * @return {void}
      */
     reverseState () {
       this.show = !this.show

--- a/src/components/DomainListHead.vue
+++ b/src/components/DomainListHead.vue
@@ -4,21 +4,22 @@
       :domain="domain"
       :report="report"/>
     <div
+      v-if="hasReport"
       id="testometer__general"
       class="testometer itemhead__testometer">
       <Doughnut
-        v-if="reportFetched"
         :score="report.score"
         :id="report.id.toString()" />
       <span class="testometer__result"> {{ report.score }} </span>
     </div>
-    <Scan :domain="domain.domain" />
+    <Scan :domain="domain.domain"/>
     <a
       class="itemhead__infolink"
       href="https://siwecos.de/support/gesamtscore">
       {{ $t('domains.more_about') }}
     </a>
     <button
+      v-if="hasReport"
       @click="reverseState"
       class="itemhead__contenttoggler">
       {{ show === true ? $t('domains.hide_details') : $t('domains.show_details') }}
@@ -38,7 +39,7 @@ export default {
     Doughnut
   },
   computed: {
-    reportFetched () {
+    hasReport () {
       return Object.keys(this.report).length > 0
     }
   },

--- a/src/components/DomainListReports.vue
+++ b/src/components/DomainListReports.vue
@@ -3,7 +3,7 @@
     <section
       :id="`${id}_${detail.scanner_name}`"
       class="detail__contentsection"
-      v-for="(detail, scannerKey) in report"
+      v-for="(detail, scannerKey) in report.report"
       :key="scannerKey">
       <h4>{{ detail.scanner_name }}</h4>
       <div class="contentsection__accordion">

--- a/src/components/Doughnut.vue
+++ b/src/components/Doughnut.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    :id="id"
+    ref="doughnut"
     class="testometer__scanometer"
     viewBox="0 0 100 100">
     <g>
@@ -25,9 +25,11 @@ export default {
   props: {
     score: {
       type: Number
-    },
-    id: {
-      type: String
+    }
+  },
+  watch: {
+    score () {
+      this.draw()
     }
   },
   methods: {
@@ -35,7 +37,7 @@ export default {
      * @return {void}
      */
     draw () {
-      let doughnut = document.getElementById(this.id).querySelector('.scanometer__value')
+      let doughnut = this.$refs.doughnut.querySelector('.scanometer__value')
       let doughnutLength = doughnut.getTotalLength()
 
       if (this.score < 50) {

--- a/src/components/ReportDetails.vue
+++ b/src/components/ReportDetails.vue
@@ -1,0 +1,33 @@
+<template>
+  <section
+    v-if="Object.keys(report).length"
+    class="item__content"
+    :class="[accordions.includes(`item__content__${reportKey}`) ? 'active' : '', `item__content__${reportKey}`]">
+    <DomainListDoughnuts
+      :report="report.report"
+      :id="report.id.toString()" />
+    <DomainListReports
+      :id="reportKey.toString()"
+      :report="report.report" />
+  </section>
+</template>
+
+<script>
+import DomainListDoughnuts from './DomainListDoughnuts'
+import DomainListReports from './DomainListReports'
+export default {
+  name: 'ReportDetails',
+  components: { DomainListReports, DomainListDoughnuts },
+  props: {
+    report: {
+      type: Object
+    },
+    accordions: {
+      type: Array
+    },
+    reportKey: {
+      type: Number
+    }
+  }
+}
+</script>

--- a/src/components/VerifiedDomains.vue
+++ b/src/components/VerifiedDomains.vue
@@ -1,6 +1,6 @@
 <template>
   <ul class="scanresults">
-    <li
+   <li
       class="item"
       v-for="(domain, key) in domains"
       :key="key">

--- a/src/components/VerifiedDomains.vue
+++ b/src/components/VerifiedDomains.vue
@@ -9,18 +9,11 @@
           v-on:toggle="toggle"
           :headId="key.toString()"
           :domain="domain"
-          :report="reports.length && reports[key] ? reports[key] : {}"/>
-        <section
-          v-if="reports.length && reports[key]"
-          class="item__content"
-          :class="[accordions.includes(`item__content__${key}`) ? 'active' : '', `item__content__${key}`]">
-          <DomainListDoughnuts
-            :report="reports[key].report"
-            :id="reports[key].id.toString()" />
-          <DomainListReports
-            :id="key.toString()"
-            :report="reports[key].report" />
-        </section>
+          :report="getAssociatedReport(domain.domain)"/>
+        <ReportDetails
+          :reportKey="key"
+          :accordions="accordions"
+          :report="getAssociatedReport(domain.domain)" />
       </div>
     </li>
   </ul>
@@ -28,8 +21,7 @@
 
 <script>
 import DomainListHead from './DomainListHead'
-import DomainListDoughnuts from './DomainListDoughnuts'
-import DomainListReports from './DomainListReports'
+import ReportDetails from './ReportDetails'
 export default {
   name: 'VerifiedDomains',
   data () {
@@ -49,9 +41,17 @@ export default {
       }
 
       this.accordions.push(state.target)
+    },
+    /**
+     *
+     * @param domain
+     * @return {*}
+     */
+    getAssociatedReport (domain) {
+      return this.reports.filter(report => report.domain === domain)[0] || {}
     }
   },
-  components: { DomainListReports, DomainListDoughnuts, DomainListHead },
+  components: { ReportDetails, DomainListHead },
   props: {
     domains: {
       type: Array


### PR DESCRIPTION
Beim bearbeiten der SIWECOS-Issues ist mir ein Bug aufgefallen, in dem die Report-Zuordnung über die Reihenfolge der Domainliste ging.

Angenommen wir haben 4 Einträge in der Domainliste ``['google.de', 'twitter.de', 'joomla.de', 'youtube.com']`` aber es existieren nur 2 Reports, weil für die anderen noch kein Scan durchgeführt wurde, dann wurden die 2 Reports vom Startindex 0 der jeweiligen Domain zugewiesen.

Dabei kann es aber sein, dass Report Nummer 2 nicht _twitter.de_ gehört (Index 1, also der zweite Eintrag im Array), sondern _youtube.com_ (4. Eintrag im Array).

Daher habe ich die Zuordnung nun refactored und in einem die Bewertungsanzeige auch aktiviert, wenn der Score bei 0 war.