### PR TITLE
Pick up scanner details

### DIFF
--- a/src/components/DomainListHead.vue
+++ b/src/components/DomainListHead.vue
@@ -68,9 +68,6 @@ export default {
     },
     report: {
       type: Object
-    },
-    headId: {
-      type: String
     }
   },
   methods: {
@@ -80,7 +77,7 @@ export default {
     reverseState () {
       this.show = !this.show
 
-      this.$emit('toggle', { target: `item__content__${this.headId}`, active: this.show })
+      this.$emit('toggle', { target: `item__content__${this.report.id.toString()}`, active: this.show })
     }
   }
 }

--- a/src/components/DomainListReports.vue
+++ b/src/components/DomainListReports.vue
@@ -3,7 +3,7 @@
     <section
       :id="`${id}_${detail.scanner_name}`"
       class="detail__contentsection"
-      v-for="(detail, scannerKey) in report.report"
+      v-for="(detail, scannerKey) in report"
       :key="scannerKey">
       <h4>{{ detail.scanner_name }}</h4>
       <div class="contentsection__accordion">

--- a/src/components/ReportDetails.vue
+++ b/src/components/ReportDetails.vue
@@ -2,12 +2,12 @@
   <section
     v-if="Object.keys(report).length"
     class="item__content"
-    :class="[accordions.includes(`item__content__${reportKey}`) ? 'active' : '', `item__content__${reportKey}`]">
+    :class="[accordions.includes(`item__content__${getReportId}`) ? 'active' : '', `item__content__${getReportId}`]">
     <DomainListDoughnuts
       :report="report.report"
-      :id="report.id.toString()" />
+      :id="getReportId" />
     <DomainListReports
-      :id="reportKey.toString()"
+      :id="getReportId"
       :report="report.report" />
   </section>
 </template>
@@ -18,15 +18,17 @@ import DomainListReports from './DomainListReports'
 export default {
   name: 'ReportDetails',
   components: { DomainListReports, DomainListDoughnuts },
+  computed: {
+    getReportId () {
+      return this.report.id.toString()
+    }
+  },
   props: {
     report: {
       type: Object
     },
     accordions: {
       type: Array
-    },
-    reportKey: {
-      type: Number
     }
   }
 }

--- a/src/components/VerifiedDomains.vue
+++ b/src/components/VerifiedDomains.vue
@@ -7,11 +7,9 @@
       <div class="item__wrapper">
         <DomainListHead
           v-on:toggle="toggle"
-          :headId="key.toString()"
           :domain="domain"
           :report="getAssociatedReport(domain.domain)"/>
         <ReportDetails
-          :reportKey="key"
           :accordions="accordions"
           :report="getAssociatedReport(domain.domain)" />
       </div>


### PR DESCRIPTION
In a past PR of [bugfix/wrong_assignment](https://github.com/SIWECOS/webapp/tree/bugfix/wrong_assignment), I've accidentally excluded a feature, which showed for each scanner, test results or details of the results in general.

In this PR, I want to include this feature again