### PR TITLE
Include URLs in scan details

### DIFF
--- a/i18n/de/common.js
+++ b/i18n/de/common.js
@@ -17,7 +17,8 @@ const common = {
   verify: 'Bestätigen',
   scan_start: 'Neuen Scan starten',
   pdf_link: 'Report als PDF',
-  error: 'Fehler'
+  error: 'Fehler',
+  urls: 'Urls'
 }
 
 export default common

--- a/i18n/en/common.js
+++ b/i18n/en/common.js
@@ -17,7 +17,8 @@ const common = {
   verify: 'Verify',
   scan_start: 'Scan start',
   error: 'Error',
-  pdf_link: 'Report as PDF'
+  pdf_link: 'Report as PDF',
+  urls: 'Urls'
 }
 
 export default common

--- a/src/components/DomainList.vue
+++ b/src/components/DomainList.vue
@@ -106,7 +106,7 @@ export default {
         let report = {}
 
         try {
-          report = await this.$api.get(`domain/${domain.domain}/report/${this.language}`)
+          report = await this.$api.get(`domain/${domain.domain}/fullreport/${this.language}`)
         } catch (e) {
           continue
         }

--- a/src/components/DomainListDoughnuts.vue
+++ b/src/components/DomainListDoughnuts.vue
@@ -4,22 +4,20 @@
     class="content__overview">
     <div
       class="itemoverview__testometercontainer"
-      v-for="(details, key) in report"
+      v-for="(score, key) in scores"
       :key="key">
-      <div
-        id="testometer__scanner1"
-        class="testometer">
-        <a :href="`#${id}_${details.scanner_name}`">
+      <div class="testometer">
+        <a :href="`#${id}_${score.name}`">
           <Doughnut
-            :score="details.score"
+            :score="score.score"
             :id="`${id}__content__${key}`"/>
         </a>
         <span class="testometer__result">
-            {{ details.score }}
-          </span>
+          {{ score.score }}
+        </span>
       </div>
       <h3>
-        {{ details.scanner_name }}
+        {{ score.name }}
       </h3>
     </div>
   </div>
@@ -33,7 +31,7 @@ export default {
     id: {
       type: String
     },
-    report: {
+    scores: {
       type: Array
     }
   },

--- a/src/components/DomainListReports.vue
+++ b/src/components/DomainListReports.vue
@@ -3,7 +3,7 @@
     <section
       :id="`${id}_${detail.scanner_name}`"
       class="detail__contentsection"
-      v-for="(detail, scannerKey) in report"
+      v-for="(detail, scannerKey) in report.report"
       :key="scannerKey">
       <h4>{{ detail.scanner_name }}</h4>
       <div class="contentsection__accordion">
@@ -18,8 +18,8 @@
             <span class="testheading__title">
               <span
                 class="testheading__icon"
-                :class="getHeadingIcon(test)"
-              ></span>
+                :class="getHeadingIcon(test)">
+              </span>
               <span v-html="test.headline"></span>
             </span>
             <span class="testheading__toggle">
@@ -34,11 +34,22 @@
             <h5 v-if="test.has_error">{{ $t('common.error') }}</h5>
             <ul v-if="test.result_details">
               <li
-                v-html="detail"
                 v-for="(detail, key) in test.result_details"
+                v-html="detail"
                 :key="key">
               </li>
             </ul>
+            <div v-if="report[detail.scanner_code] && report[detail.scanner_code].length">
+              <b>{{ $t('common.urls').toUpperCase() }}</b>
+              <ul>
+                <li
+                  v-for="(url, urlKey) in report[detail.scanner_code]"
+                  :key="urlKey"
+                  v-if="url.headline === test.headline">
+                  {{ url.domain }}
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
@@ -60,9 +71,14 @@ export default {
       shownTests: {}
     }
   },
+  watch: {
+    report (item) {
+      console.log(item)
+    }
+  },
   props: {
     report: {
-      type: Array
+      type: Object
     },
     id: {
       type: String

--- a/src/components/DomainListReports.vue
+++ b/src/components/DomainListReports.vue
@@ -40,15 +40,9 @@
               </li>
             </ul>
             <div v-if="report[detail.scanner_code] && report[detail.scanner_code].length">
-              <b>{{ $t('common.urls').toUpperCase() }}</b>
-              <ul>
-                <li
-                  v-for="(url, urlKey) in report[detail.scanner_code]"
-                  :key="urlKey"
-                  v-if="url.headline === test.headline">
-                  {{ url.domain }}
-                </li>
-              </ul>
+              <Urls
+                :urls="report[detail.scanner_code]"
+                :headline="test.headline" />
             </div>
           </div>
         </div>
@@ -63,17 +57,14 @@
 </template>
 
 <script>
+import Urls from './Urls'
 export default {
   name: 'DomainListReports',
+  components: { Urls },
   data () {
     return {
       accordions: [],
       shownTests: {}
-    }
-  },
-  watch: {
-    report (item) {
-      console.log(item)
     }
   },
   props: {

--- a/src/components/DomainListReports.vue
+++ b/src/components/DomainListReports.vue
@@ -17,8 +17,8 @@
             class="accordionitem__heading">
             <span class="testheading__title">
               <span
-                      class="testheading__icon"
-                      :class="getHeadingIcon(test)"
+                class="testheading__icon"
+                :class="getHeadingIcon(test)"
               ></span>
               <span v-html="test.headline"></span>
             </span>

--- a/src/components/ReportDetails.vue
+++ b/src/components/ReportDetails.vue
@@ -5,10 +5,10 @@
     :class="[accordions.includes(`item__content__${getReportId}`) ? 'active' : '', `item__content__${getReportId}`]">
     <DomainListDoughnuts
       :scores="scores"
-      :id="getReportId" />
+      :id="getReportId"/>
     <DomainListReports
       :id="getReportId"
-      :report="report.report" />
+      :report="getReport"/>
   </section>
 </template>
 
@@ -19,9 +19,53 @@ export default {
   name: 'ReportDetails',
   components: { DomainListReports, DomainListDoughnuts },
   computed: {
+    /**
+     * @return {string}
+     */
     getReportId () {
       return this.report.id.toString()
     },
+    /**
+     * @return {{}}
+     */
+    getReport () {
+      // https://backupmonkey.io/: Object => report { score: 100, tests: [...], ... }
+      // mx01.hosting.de: Object
+      let reports = this.report.reports
+      let reportsClone = { ...this.report.reports }
+      let details = {}
+
+      Reflect.deleteProperty(reportsClone, `https://${this.report.domain}/`)
+
+      // This is the main domain
+      let domainObject = reports[`https://${this.report.domain}/`]
+
+      if (domainObject) {
+        Reflect.set(details, 'report', domainObject.report)
+      }
+
+      for (let domain in reportsClone) {
+        for (let report of reportsClone[domain].report) {
+          if (!Reflect.get(details, report.scanner_code)) {
+            Reflect.set(details, report.scanner_code, [])
+          }
+
+          for (let test of report.tests) {
+            if (test.score === 100 && test.has_error === false) {
+              continue
+            }
+
+            details[report.scanner_code].push({ domain, headline: test.headline })
+          }
+        }
+      }
+
+      return details
+    },
+    /**
+     *
+     * @return {[]|Array}
+     */
     scores () {
       let scores = []
 
@@ -29,7 +73,7 @@ export default {
         .keys(this.report.scanner_scores)
         .forEach(name => scores.push({ name, score: this.report.scanner_scores[name] }))
 
-      return scores
+      return scores || []
     }
   },
   props: {

--- a/src/components/ReportDetails.vue
+++ b/src/components/ReportDetails.vue
@@ -51,24 +51,23 @@ export default {
           continue
         }
 
-        // Special handling for mail servers as those use other scanners
-        if (reportUrl.includes('mx')) {
-          this.fetchReport(urls[reportUrl].report, item => {
-            if (!Reflect.get(data, item.scanner_code) && item.tests.length) {
-              data.report.push(item)
-            }
-          })
-        }
-
         this.fetchReport(urls[reportUrl].report, item => {
+          if (!Reflect.get(data, item.scanner_code) && item.tests.length) {
+            Reflect.set(data, item.scanner_code, [])
+
+            data.report.push(item)
+          }
+
           // In this case it is probably a mail server scanner which has been included as an report item before
-          if (!item.scanner_code) {
-            throw new Error('Scanner not defined')
+          if (!Reflect.get(data, item.scanner_code)) {
+            throw new Error('Scanner not found')
           }
 
           data[item.scanner_code].push(...this.getAffectedUrls(item.tests, reportUrl))
         })
       }
+
+      console.log(data)
 
       return data
     },

--- a/src/components/ReportDetails.vue
+++ b/src/components/ReportDetails.vue
@@ -4,7 +4,7 @@
     class="item__content"
     :class="[accordions.includes(`item__content__${getReportId}`) ? 'active' : '', `item__content__${getReportId}`]">
     <DomainListDoughnuts
-      :report="report.report"
+      :scores="scores"
       :id="getReportId" />
     <DomainListReports
       :id="getReportId"
@@ -21,6 +21,15 @@ export default {
   computed: {
     getReportId () {
       return this.report.id.toString()
+    },
+    scores () {
+      let scores = []
+
+      Object
+        .keys(this.report.scanner_scores)
+        .forEach(name => scores.push({ name, score: this.report.scanner_scores[name] }))
+
+      return scores
     }
   },
   props: {

--- a/src/components/Urls.vue
+++ b/src/components/Urls.vue
@@ -1,0 +1,40 @@
+<script>
+export default {
+  name: 'Urls',
+  props: {
+    urls: {
+      type: Array
+    },
+    headline: {
+      type: String
+    }
+  },
+  render (h) {
+    let header = this.getNames(h).length ? this.$t('common.urls') : ''
+
+    return h('ul', [header, ...this.getNames(h)])
+  },
+  methods: {
+    /**
+     *
+     * @param h
+     * @return {[]}
+     */
+    getNames (h) {
+      let names = []
+
+      for (let url of this.urls) {
+        if (url.headline === this.headline) {
+          names.push(h('li', url.domain))
+        }
+      }
+
+      return names
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
Mit dem PR ist es möglich, URLs oder subdomains mit in den Scan-Ergebnissen aufzulisten. Somit sieht man nicht nur die Ergebnisse der Hauptdomain, sondern auch der anderen zugehörigen Seiten.